### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ A Model Completion Protocol (MCP) server for the [Cryo](https://github.com/parad
 
 Cryo MCP allows you to access Cryo's powerful blockchain data extraction capabilities via an API server that implements the MCP protocol, making it easy to query blockchain data from any MCP-compatible client.
 
+<a href="https://glama.ai/mcp/servers/90ftd26na5">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/90ftd26na5/badge" alt="Cryo Server MCP server" />
+</a>
+
 ## For LLM Users: SQL Query Workflow Guide
 
 When using this MCP server to run SQL queries on blockchain data, follow this workflow:


### PR DESCRIPTION
This PR adds a badge for the [Cryo MCP Server](https://glama.ai/mcp/servers/90ftd26na5) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/90ftd26na5">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/90ftd26na5/badge" alt="Cryo Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.